### PR TITLE
chore(deps): update dependency @favware/cliff-jumper to ^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.2.1",
     "@commitlint/config-conventional": "^19.1.0",
-    "@favware/cliff-jumper": "^3.0.1",
+    "@favware/cliff-jumper": "^3.0.2",
     "@favware/npm-deprecate": "^1.0.7",
     "@sapphire/eslint-config": "^5.0.4",
     "@sapphire/ts-config": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,9 +647,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@favware/cliff-jumper@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@favware/cliff-jumper@npm:3.0.1"
+"@favware/cliff-jumper@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@favware/cliff-jumper@npm:3.0.2"
   dependencies:
     "@favware/colorette-spinner": ^1.0.1
     "@sapphire/result": ^2.6.6
@@ -659,13 +659,13 @@ __metadata:
     compare-func: ^2.0.0
     conventional-recommended-bump: ^9.0.0
     execa: ^8.0.1
-    git-cliff: ^2.1.2
+    git-cliff: ^2.2.1
     js-yaml: ^4.1.0
     semver: ^7.6.0
   bin:
     cj: ./dist/cli.js
     cliff-jumper: ./dist/cli.js
-  checksum: fcc1fe3a7724307be6d03c1bacff8b4d332c1ec34457a4f4a9a7146c2c0834fa13a6710cb71177c3ca5a46849d53a587b496fe0a3c50af63bb8766deb269537d
+  checksum: 55fa9444ad5ad618b1aa02f29aae3d4eba5f26ad842b47338c8222da1e0a572d1af898ca8bfd549f843938b4d2850465707133d5d5e336b895e33a2cf99ac940
   languageName: node
   linkType: hard
 
@@ -2817,59 +2817,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-arm64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-darwin-arm64@npm:2.2.0"
+"git-cliff-darwin-arm64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-darwin-arm64@npm:2.2.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-x64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-darwin-x64@npm:2.2.0"
+"git-cliff-darwin-x64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-darwin-x64@npm:2.2.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-arm64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-linux-arm64@npm:2.2.0"
+"git-cliff-linux-arm64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-linux-arm64@npm:2.2.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-x64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-linux-x64@npm:2.2.0"
+"git-cliff-linux-x64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-linux-x64@npm:2.2.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-arm64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-windows-arm64@npm:2.2.0"
+"git-cliff-windows-arm64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-windows-arm64@npm:2.2.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-x64@npm:2.2.0":
-  version: 2.2.0
-  resolution: "git-cliff-windows-x64@npm:2.2.0"
+"git-cliff-windows-x64@npm:2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff-windows-x64@npm:2.2.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff@npm:^2.1.2":
-  version: 2.2.0
-  resolution: "git-cliff@npm:2.2.0"
+"git-cliff@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "git-cliff@npm:2.2.1"
   dependencies:
     execa: ^8.0.1
-    git-cliff-darwin-arm64: 2.2.0
-    git-cliff-darwin-x64: 2.2.0
-    git-cliff-linux-arm64: 2.2.0
-    git-cliff-linux-x64: 2.2.0
-    git-cliff-windows-arm64: 2.2.0
-    git-cliff-windows-x64: 2.2.0
+    git-cliff-darwin-arm64: 2.2.1
+    git-cliff-darwin-x64: 2.2.1
+    git-cliff-linux-arm64: 2.2.1
+    git-cliff-linux-x64: 2.2.1
+    git-cliff-windows-arm64: 2.2.1
+    git-cliff-windows-x64: 2.2.1
   dependenciesMeta:
     git-cliff-darwin-arm64:
       optional: true
@@ -2885,7 +2885,7 @@ __metadata:
       optional: true
   bin:
     git-cliff: lib/cli/cli.js
-  checksum: fe698b5463345b80455629cd8768bfc84028ef4005a6bf7959f6f09540cd7ce50b60d65a4b11323b11fdcb9b3a3a1af93d22d8198529d9572cea55b38fe68e68
+  checksum: ee18e17f38424fa5b992e59fbf4024ddf5e8f3213011ed3393b063b71a857b4a032ab36954f3e4f89c3e1035fdb4c6c1cc1bf33b77df06ce47aa3322c101ee1c
   languageName: node
   linkType: hard
 
@@ -4486,7 +4486,7 @@ __metadata:
   dependencies:
     "@commitlint/cli": ^19.2.1
     "@commitlint/config-conventional": ^19.1.0
-    "@favware/cliff-jumper": ^3.0.1
+    "@favware/cliff-jumper": ^3.0.2
     "@favware/npm-deprecate": ^1.0.7
     "@sapphire/eslint-config": ^5.0.4
     "@sapphire/ts-config": ^5.0.1


### PR DESCRIPTION
Fixes the release process for this repository.